### PR TITLE
Refactor: added new local provider: LM Studio.

### DIFF
--- a/settings/default.json
+++ b/settings/default.json
@@ -20,8 +20,8 @@
             "name": "lm-studio",
             "services": [
                 {
-                    "name": "codellama",
-                    "model": "codellama-rust-finetune"
+                    "name": "deepseek",
+                    "model": "deepseek-coder-6.7B-instruct"
                 }
             ],
             "default_service": "codellama",

--- a/src/dev_mode/mod.rs
+++ b/src/dev_mode/mod.rs
@@ -16,12 +16,7 @@ pub mod comment_summary {
         info!("Mod: Testing summary creation.");
 
         let repo_review = _deserialize_repository_review_from(
-            settings
-                .developer_mode
-                .clone()
-                .unwrap()
-                .test_json_file
-                .unwrap(),
+            settings.developer_mode.clone().unwrap().test_file.unwrap(),
         )?;
 
         // Create a [`ReviewSummary`]
@@ -120,6 +115,59 @@ pub mod test_settings {
         info!("Provider settings: {:?}", get_service_and_model(settings));
 
         Ok(())
+    }
+}
+
+#[cfg(debug_assertions)]
+pub mod test_providers {
+    use std::fs::File;
+    use std::io::Read;
+
+    use log::info;
+
+    use crate::{
+        provider::{
+            api::{ProviderCompletionMessage, ProviderMessageRole},
+            review_or_summarise,
+        },
+        settings::Settings,
+    };
+
+    pub(crate) async fn _test_local_provider(
+        settings: &Settings,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Mod: Testing local LM Studio provider.");
+
+        let test_source_file = settings.developer_mode.clone().unwrap().test_file.unwrap();
+        let request_type = crate::provider::RequestType::Review;
+        let provider: &crate::settings::ProviderSettings = settings.get_active_provider()?;
+        let prompt_data = crate::provider::prompts::PromptData {
+            id: None,
+            messages: vec![ProviderCompletionMessage {
+                role: ProviderMessageRole::System,
+                content: "As an expert code reviewer with comprehensive knowledge in software development standards, review the following code.".to_string(),
+            },ProviderCompletionMessage {
+                role: ProviderMessageRole::System,
+                content: "Provide your analysis strictly in valid JSON format. Strictly escape any characters within your response strings that will create invalid JSON, such as \" - i.e., quotes - use a single escape character. Never use comments in your JSON..".to_string(),
+            },ProviderCompletionMessage {
+                role: ProviderMessageRole::User,
+                content: "Please review the following code. Keep you review short and to the point.".to_string(),
+            },ProviderCompletionMessage {
+                role: ProviderMessageRole::User,
+                content: get_code_str(test_source_file)?,
+            }],
+        };
+        let result = review_or_summarise(request_type, settings, provider, &prompt_data).await?;
+        info!("Result: {:?}", result);
+        Ok(())
+    }
+
+    fn get_code_str(file_path: String) -> Result<String, Box<dyn std::error::Error>> {
+        let mut file = File::open(file_path)?;
+        let mut file_contents = String::new();
+        file.read_to_string(&mut file_contents)?;
+
+        Ok(file_contents)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // dev_mode::code_frequency::_test_total_commits(&settings)?;
             // dev_mode::code_frequency::_test_code_frequency(&settings)?;
             // dev_mode::_comment_summary::test_summary(&settings).await?;
-            dev_mode::test_settings::_test_provider_settings(&settings)?;
+            // dev_mode::test_settings::_test_provider_settings(&settings)?;
+            dev_mode::test_providers::_test_local_provider(&settings).await?;
         }
     }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -2,8 +2,8 @@
 //!  Handles the access to the LLM with utility functions for specified actions
 //!
 pub(crate) mod api;
-mod lmstudio;
-mod openai;
+pub(crate) mod lmstudio;
+pub(crate) mod openai;
 pub(crate) mod prompts;
 use crate::provider::prompts::PromptData;
 use crate::settings::{ProviderSettings, ServiceSettings, Settings};

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -247,7 +247,7 @@ pub(crate) struct DeveloperMode {
     pub(crate) verbose_data_output: bool,
     #[serde(default = "default_false")]
     pub(crate) test_path: bool,
-    pub(crate) test_json_file: Option<String>,
+    pub(crate) test_file: Option<String>,
 }
 #[derive(Serialize, Deserialize, PartialEq)]
 pub(crate) struct SensitiveSettings {


### PR DESCRIPTION
Added local testing path to tune prompts. 
Works, but does not allow for large files locally or adheres to prompt mechanism used for OpenAI hosted models